### PR TITLE
Cache as read layer for the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,14 @@ Service uses 2 contracts living on the Besu node on the sidechain (`mainnet`).
 
 <details>
     <summary>/v1/stargate</summary>
-    Returns stargate address, tll_expiry and list of assets.
+    Returns stargate address, tll_expire, cache_update and list of assets.
     (For now only stargate address is fetched from bridge contract)
 
 ```json
 {
     "current_address": "addr1...",
-    "ttl_expiry": 123,
+    "ttl_expire": 123,
+    "cacheIntervalMs": 123,
     "ada": {
         "minLovelace": "2000000",
         "fromADAFeeLovelace": "100000",

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Service uses 2 contracts living on the Besu node on the sidechain (`mainnet`).
 ```json
 {
     "current_address": "addr1...",
-    "ttl_expire": 123,
+    "ttl_expiry": 123,
     "ada": {
         "minLovelace": "2000000",
         "fromADAFeeLovelace": "100000",

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Service uses 2 contracts living on the Besu node on the sidechain (`mainnet`).
 {
     "current_address": "addr1...",
     "ttl_expire": 123,
-    "cacheIntervalMs": 123,
     "ada": {
         "minLovelace": "2000000",
         "fromADAFeeLovelace": "100000",

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # AllowedList Service
-[![Node.js CI](https://github.com/dcSpark/pricing-service/actions/workflows/node.js.yml/badge.svg?branch=main)](https://github.com/dcSpark/pricing-service/actions/workflows/node.js.yml)
 
+[![Node.js CI](https://github.com/dcSpark/pricing-service/actions/workflows/node.js.yml/badge.svg?branch=main)](https://github.com/dcSpark/pricing-service/actions/workflows/node.js.yml)
 
 ## Background
 
-
 ## Purpose of this project
+
 The purpose of this micro service is to provide a list of addresses that are allowed to use the bridge in Milkomeda.
 
 ## Building
 
 Development build (with hot reloading):
+
 ```bash
 # install the right version of Node
 nvm use
@@ -22,19 +23,23 @@ npm install
 # run the server
 npm run start
 ```
-*Never put production credentials into any repository!*
+
+_Never put production credentials into any repository!_
 
 Feel free to test it using:
+
 ```sh
 curl  http://localhost:3000/v1/isAddressAllowed?address=addr1qxm9k70p3j54qfgvvhx39rh0kfm6k4lxyfkavks0cm7kklxlmylqk3ksyqnhe8dadcee2a5syrc8a2salkpa3e0sp76symvshl
 ```
+
 Should return `{"isAllowed":true}`
 
 ## Containers
-This will build to a container with the docker file.  The container is using the PM2 runtime.  You will need to pass ENV variables to the container to register with PM2 logging.
 
+This will build to a container with the docker file. The container is using the PM2 runtime. You will need to pass ENV variables to the container to register with PM2 logging.
 
 ## Tests
+
 =======
 I had to add 2 env variables to deploy it working on Heroku:
 
@@ -44,43 +49,48 @@ heroku config:set USE_NPM_INSTALL=true -a allowedlist-service
 ```
 
 ## Containers
+
 N/A for now
 Do not try to use them!
 
 # Deployments
+
 The default configuration of `sidechain` section consists of values which should allow to connect to `mainnet` contract when deployed.
 Values can be also set using `environmental` variables such as:
- * `CONTRACT_HOST` - url to Besu node e.g. `http://localhost:8545`
- * `ALLOW_LIST_CONTRACT_ADDRESS` - address of the allowlist contract deployed on the besu node in the sidechain
- * `BRIDGE_CONTRACT_CHAIN_ID` - bridge contract has different chainId depending on the environment. For `devnet` it's `200101` and for `mainnet` it's `2001`
+
+-   `CONTRACT_HOST` - url to Besu node e.g. `http://localhost:8545`
+-   `ALLOW_LIST_CONTRACT_ADDRESS` - address of the allowlist contract deployed on the besu node in the sidechain
+-   `BRIDGE_CONTRACT_CHAIN_ID` - bridge contract has different chainId depending on the environment. For `devnet` it's `200101` and for `mainnet` it's `2001`
 
 # Contracts
+
 Service uses 2 contracts living on the Besu node on the sidechain (`mainnet`).
+
 1. `AllowedList Contract` - requires 2 files (inside `contracts/` directory):
-   * `AccountIngress.json` - required to initialize account ingress contract & fetch necessary contract rules
-   * `AccountRulesList.json`  - required to fetch specific functionalities like `getAccounts()`
-  
+
+    - `AccountIngress.json` - required to initialize account ingress contract & fetch necessary contract rules
+    - `AccountRulesList.json` - required to fetch specific functionalities like `getAccounts()`
+
 2. `Bridge Contract` - requires 2 files (inside `contracts/` directory):
-   * `Proxy.json` - introduces sidechain bridge contract key initialization features
-   * `SidechainBridge.json` - introduces sidechain bridge contract functionalities
+    - `Proxy.json` - introduces sidechain bridge contract key initialization features
+    - `SidechainBridge.json` - introduces sidechain bridge contract functionalities
 
 # Endpoints
+
 <details>
     <summary>/v1/fullAllowedList</summary>
     Returns array of EVM addresses allowed in the mainnet (`http://localhost:3000/v1/fullAllowedList`).
 
 ```json
 {
-    "allowList": [
-        "0x...",
-        "0x...",
-    ]
+    "allowList": ["0x...", "0x..."]
 }
 ```
+
 </details>
 
 <details>
-    <summary>/v1/fullAllowedList</summary>
+    <summary>/v1/isAddressAllowed</summary>
     Returns information if given address is on allowed list or not.(`http://localhost:3000/v1/isAddressAllowed?address=0x0...`).
 
 ```json
@@ -88,6 +98,7 @@ Service uses 2 contracts living on the Besu node on the sidechain (`mainnet`).
     "isAllowed": true
 }
 ```
+
 </details>
 
 <details>
@@ -111,8 +122,33 @@ Service uses 2 contracts living on the Besu node on the sidechain (`mainnet`).
             "idMilkomeda": "ERC20 contract address",
             "minCNTInt": "1",
             "minGWei": "10000...000"
-        },
+        }
     ]
 }
 ```
+
+</details>
+
+<details>
+    <summary>/v1/clearCache</summary>
+    Allows to flush the cache storage.
+
+```json
+{
+    "message": "Cache flushed."
+}
+```
+
+</details>
+
+<details>
+    <summary>/v1/updateCache</summary>
+    Cache is being updated in interval of time. If we need to update cache `now`, this endpoint allows to do that.
+
+```json
+{
+    "message": "Cache storage updated."
+}
+```
+
 </details>

--- a/README.md
+++ b/README.md
@@ -128,27 +128,3 @@ Service uses 2 contracts living on the Besu node on the sidechain (`mainnet`).
 ```
 
 </details>
-
-<details>
-    <summary>/v1/clearCache</summary>
-    Allows to flush the cache storage.
-
-```json
-{
-    "message": "Cache flushed."
-}
-```
-
-</details>
-
-<details>
-    <summary>/v1/updateCache</summary>
-    Cache is being updated in interval of time. If we need to update cache `now`, this endpoint allows to do that.
-
-```json
-{
-    "message": "Cache storage updated."
-}
-```
-
-</details>

--- a/config/default.ts
+++ b/config/default.ts
@@ -1,8 +1,8 @@
 export default {
     sidechain: {
-        nodeUrl: process.env.CONTRACT_HOST || "wss://use-util.cloud.milkomeda.com:8556",
+        nodeUrl: process.env.CONTRACT_HOST || "wss://rpc.c1.milkomeda.com:8546",
         accountIngressAddress: process.env.ALLOW_LIST_CONTRACT_ADDRESS || "0x0000000000000000000000000000000000008888",
-        chainId: process.env.BRIDGE_CONTRACT_CHAIN_ID || 200101,
+        chainId: process.env.BRIDGE_CONTRACT_CHAIN_ID || 2001,
         accountIngress: "./contract/AccountIngress.json",
         accountRulesList: "./contract/AccountRulesList.json",
         bridgeProxyContract: "./contract/Proxy.json",
@@ -12,5 +12,6 @@ export default {
         port: process.env.PORT || 3000,
         enforceWhitelist: process.env.WHITELIST || "FALSE",
         mainnet: process.env.MAINNET || "FALSE",
+        cacheIntervalMs: 3600000 // update cache every hour
     },
 } as ConfigType;

--- a/config/default.ts
+++ b/config/default.ts
@@ -1,8 +1,8 @@
 export default {
     sidechain: {
-        nodeUrl: process.env.CONTRACT_HOST || "https://rpc.c1.milkomeda.com:8545",
+        nodeUrl: process.env.CONTRACT_HOST || "wss://use-util.cloud.milkomeda.com:8556",
         accountIngressAddress: process.env.ALLOW_LIST_CONTRACT_ADDRESS || "0x0000000000000000000000000000000000008888",
-        chainId: process.env.BRIDGE_CONTRACT_CHAIN_ID || 2001,
+        chainId: process.env.BRIDGE_CONTRACT_CHAIN_ID || 200101,
         accountIngress: "./contract/AccountIngress.json",
         accountRulesList: "./contract/AccountRulesList.json",
         bridgeProxyContract: "./contract/Proxy.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "express": "^5.0.0-alpha.8",
         "mocha": "^9.1.1",
+        "node-cache": "^5.1.2",
         "pm2": "^5.1.1",
         "semver-compare": "^1.0.0",
         "web3": "^1.6.0"
@@ -2698,6 +2699,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -6978,6 +6987,17 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/node-cleanup": {
       "version": "2.1.2",
@@ -13537,6 +13557,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -16832,6 +16857,14 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      }
     },
     "node-cleanup": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.5",
     "express": "^5.0.0-alpha.8",
     "mocha": "^9.1.1",
+    "node-cache": "^5.1.2",
     "pm2": "^5.1.1",
     "semver-compare": "^1.0.0",
     "web3": "^1.6.0"

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,65 @@
+import NodeCache from "node-cache";
+import { delay } from "../utils";
+
+export type CacheOption = {
+    key: CacheKeys;
+    method: () => unknown;
+};
+
+export enum CacheKeys {
+    STARGATE = "STARGATE",
+    TOKEN_REGISTRY = "TOKEN_REGISTRY",
+    FULL_ALLOWED_LIST = "FULL_ALLOWED_LIST"
+}
+
+// updating mechanics:
+// query sidechain every n seconds and update cache for each request
+// in the meantime allow access to current state of cache and allow to query it, even while the update happens
+export class CacheManager {
+    cacheStore: NodeCache;
+
+    constructor(secondsTTL?: number) {
+        this.cacheStore = new NodeCache({
+            stdTTL: secondsTTL ?? 0,
+            useClones: false,
+        });
+    }
+
+    public updateCache = async (actions: CacheOption[]) => {
+        for (let action of actions) {
+            console.log(`Updating ${action.key}`);
+            const result = await action.method();
+            // console.log(result);
+            this.save(action.key, result);
+        }
+    }
+
+    public keepCached = async (actions: CacheOption[], intervalMs: number = 20000): Promise<void> => {
+        await this.updateCache(actions);
+        await delay(intervalMs);
+        this.keepCached(actions, intervalMs);
+    }
+
+    public save(key: string, item: unknown): void {
+        console.log(`saving to cache... key: ${key}`);
+        this.cacheStore.set(key, item);
+    }
+
+    public async get(key: string): Promise<unknown | null> {
+        console.log(`getting from cache... key: ${key}`);
+        const value = await this.cacheStore.get(key);
+        if (value) return value;
+        return null;
+    }
+
+    public delete(keys: string[]): void {
+        this.cacheStore.del(keys);
+    }
+
+    public flush(): void {
+        console.log("Resetting cache...");
+        this.cacheStore.flushAll();
+    }
+}
+
+export const cacheManager = new CacheManager();

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,5 +1,4 @@
 import NodeCache from "node-cache";
-import { delay } from "../utils";
 
 export type CacheOption = {
     key: CacheKeys;
@@ -35,9 +34,10 @@ export class CacheManager {
     }
 
     public keepCached = async (actions: CacheOption[], intervalMs: number = 20000): Promise<void> => {
-        await this.updateCache(actions);
-        await delay(intervalMs);
-        this.keepCached(actions, intervalMs);
+        await this.updateCache(actions); // load first time - setInterval runs then scheduled jobs and first one starts after intervalMs
+        setInterval(async () => {
+            await this.updateCache(actions);
+        }, intervalMs);
     }
 
     public save(key: string, item: unknown): void {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -9,12 +9,12 @@ import { WMAIN_ID } from "./utils";
 
 declare const CONFIG: ConfigType;
 
-type TokensRegistry = {
+export type TokensRegistry = {
     minLovelace: string,
     assets: AssetsDetails[]
 };
 
-type AssetsDetails = {
+export type AssetsDetails = {
     idCardano: string;
     idMilkomeda: string;
     minCNTInt?: string;
@@ -42,6 +42,7 @@ export class AllowedListContract {
                 bridgeLogic["abi"] as AbiItem[],
                 bridgeProxy["networks"][CONFIG.sidechain.chainId]["address"]
             );
+
         } catch (e) {
             console.error(e);
         }
@@ -54,11 +55,10 @@ export class AllowedListContract {
 
         assert(isAddress(accountRulesAddress));
         this.allowedListContract = new this.web3.eth.Contract(accountRulesList["abi"] as AbiItem[], accountRulesAddress);
-
         return this;
     }
 
-    public async getAccountsList(): Promise<string[] | Error> {
+    public getAccountsList = async (): Promise<string[] | Error> => {
         try {
             return await this.allowedListContract.methods.getAccounts().call();
         } catch (e: any) {
@@ -68,7 +68,7 @@ export class AllowedListContract {
         }
     }
 
-    public async getStargateAddress(): Promise<string[] | Error> {
+    public getStargateAddress = async (): Promise<string[] | Error> => {
         try {
             return await this.bridgeContract.methods.stargateAddress().call();
         } catch (e: any) {
@@ -120,4 +120,5 @@ export class AllowedListContract {
         return tokenRegistry;
     };
 }
+
 export const contract = new AllowedListContract();

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ const fullAddressList = async (req: Request, res: Response): Promise<void> => {
     } catch (e) {
         const err = e as Error;
         console.log(`${err.name}, ${err.message}, ${err.stack}`);
-        res.status(400).send({ error: `Couldn't fetch nnformation about allowed list. ${err.message}` });
+        res.status(400).send({ error: `Couldn't fetch information about allowed list. ${err.message}` });
         return;
     }
 };
@@ -86,33 +86,19 @@ const stargate = async (req: Request, res: Response) => {
     try {
         const stargateAddress = await cacheManager.get(CacheKeys.STARGATE) as string;
         const tokenRegistry = await cacheManager.get(CacheKeys.TOKEN_REGISTRY) as TokensRegistry;
-        
-        // TODO: Update config so node parses this env variable as a Boolean
-        // TODO: do we still need to distinguish between mainnet & devnet here?
-        if (CONFIG.API.mainnet === "TRUE") {
-            res.send({
-                current_address: stargateAddress,
-                ttl_expire: new Date().setHours(24, 0, 0, 0),
-                ada: {
-                    minLovelace: tokenRegistry.minLovelace,
-                    fromADAFeeLovelace: "500000",
-                    toADAFeeGWei: "500000"
-                },
-                assets: tokenRegistry.assets,
-            });
-            return;
-        } else {
-            res.send({
-                current_address: stargateAddress,
-                ttl_expire: new Date().setHours(24, 0, 0, 0),
-                ada: {
-                    minLovelace: tokenRegistry.minLovelace,
-                    fromADAFeeLovelace: "500000",
-                    toADAFeeGWei: "500000"
-                },
-                assets: tokenRegistry.assets,
-            });
-        }
+
+        res.send({
+            current_address: stargateAddress,
+            ttl_expiry: new Date().setHours(24, 0, 0, 0),
+            ada: {
+                minLovelace: tokenRegistry.minLovelace,
+                fromADAFeeLovelace: "500000",
+                toADAFeeGWei: "500000"
+            },
+            assets: tokenRegistry.assets,
+        });
+        return;
+
     } catch (e) {
         const err = e as Error;
         console.log(`${err.name}, ${err.message}, ${err.stack}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,30 +121,6 @@ const stargate = async (req: Request, res: Response) => {
     }
 };
 
-const clearCache = async (req: Request, res: Response): Promise<void> => {
-    try {
-        cacheManager.flush();
-        res.status(200).send({ message: "Cache flushed." });
-    } catch (e) {
-        const err = e as Error;
-        console.log(`${err.name}, ${err.message}, ${err.stack}`);
-        res.status(400).send({ error: `Couldn't clear the cache. ${err.message}` });
-        return;
-    }
-};
-
-const updateCache = async (req: Request, res: Response): Promise<void> => {
-    try {
-        cacheManager.updateCache(injectForCaching);
-        res.status(200).send({ message: "Cache storage updated.." });
-    } catch (e) {
-        const err = e as Error;
-        console.log(`${err.name}, ${err.message}, ${err.stack}`);
-        res.status(400).send({ error: `Couldn't clear the cache. ${err.message}` });
-        return;
-    }
-};
-
 const routes: Route[] = [
     {
         path: "/v1/isAddressAllowed",
@@ -160,16 +136,6 @@ const routes: Route[] = [
         path: "/v1/stargate",
         method: "get",
         handler: stargate,
-    },
-    {
-        path: "/v1/clearCache",
-        method: "get",
-        handler: clearCache,
-    },
-    {
-        path: "/v1/updateCache",
-        method: "get",
-        handler: updateCache,
     },
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,6 @@ const stargate = async (req: Request, res: Response) => {
             res.send({
                 current_address: stargateAddress,
                 ttl_expire: new Date().setHours(24, 0, 0, 0),
-                cache_update: CONFIG.API.cacheIntervalMs,
                 ada: {
                     minLovelace: tokenRegistry.minLovelace,
                     fromADAFeeLovelace: "500000",
@@ -106,7 +105,6 @@ const stargate = async (req: Request, res: Response) => {
             res.send({
                 current_address: stargateAddress,
                 ttl_expire: new Date().setHours(24, 0, 0, 0),
-                cache_update: CONFIG.API.cacheIntervalMs,
                 ada: {
                     minLovelace: tokenRegistry.minLovelace,
                     fromADAFeeLovelace: "500000",

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ const stargate = async (req: Request, res: Response) => {
             res.send({
                 current_address: stargateAddress,
                 ttl_expire: new Date().setHours(24, 0, 0, 0),
+                cache_update: CONFIG.API.cacheIntervalMs,
                 ada: {
                     minLovelace: tokenRegistry.minLovelace,
                     fromADAFeeLovelace: "500000",
@@ -105,6 +106,7 @@ const stargate = async (req: Request, res: Response) => {
             res.send({
                 current_address: stargateAddress,
                 ttl_expire: new Date().setHours(24, 0, 0, 0),
+                cache_update: CONFIG.API.cacheIntervalMs,
                 ada: {
                     minLovelace: tokenRegistry.minLovelace,
                     fromADAFeeLovelace: "500000",
@@ -119,7 +121,6 @@ const stargate = async (req: Request, res: Response) => {
         res.status(400).send({ error: `Couldn't get information about sidechain contract. ${err.message}` });
         return;
     }
-   
 };
 
 const clearCache = async (req: Request, res: Response): Promise<void> => {
@@ -192,7 +193,7 @@ contract
         // always start REST API
         server.listen(port, () => console.log(`listening on ${port}...`));
                 
-        cacheManager.keepCached(injectForCaching, 3600)
+        cacheManager.keepCached(injectForCaching, CONFIG.API.cacheIntervalMs)
         .then((_) => console.log("Cache updater initialized"))
         .catch((e: unknown) => console.error(e));
     });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -52,3 +52,5 @@ export function scanInteger(x: any, strict = false): Nullable<number> {
             return null;
     }
 }
+
+export const delay = async (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -52,5 +52,3 @@ export function scanInteger(x: any, strict = false): Nullable<number> {
             return null;
     }
 }
-
-export const delay = async (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/types/globals/index.d.ts
+++ b/types/globals/index.d.ts
@@ -12,6 +12,7 @@ interface ConfigType {
         port: number;
         enforceWhitelist: string;
         mainnet: string;
+        cacheIntervalMs: number;
     };
 }
 


### PR DESCRIPTION
## Problem
Now, whenever there was a request made to the API, the sidechain was queried. It had very bad performance, because many connections were made at a time to read data from the contract.

## Solution
This PR introduces caching layer. The client now can only read from cache (so the response is given almost instantly & number of clients calling the api has no impact on the sidechain). 


- [x] cache layer - save/get/flush/delete
- [x] function for automatic cache update

Cache is updated every hour (interval can be set to a different one if needed). ~~To control what happens in the cache there are 2 new endpoints introduced with this PR:~~
- [x] ~~`/clearCache` - to clear the cache if necessary~~ - removed
- [x]  ~~`/updateCache` - if we need results from the sidechain at the very moment, we can call this function and force cache to update, without a need to wait until the time of automatic update~~ - removed
