### PR TITLE
remove allowedlist limitations for isAddressAllowed

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -7,7 +7,6 @@ export default {
     },
     API: {
         port: process.env.PORT || 3000,
-        enforceWhitelist: process.env.WHITELIST || "FALSE",
         mainnet: process.env.MAINNET || "FALSE",
         cacheIntervalMs: 1800000, // update cache every hour
         allowedAddressesCSV: "./files/allowed_addresses.csv",

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,30 +54,9 @@ const fullAddressList = async (req: Request, res: Response): Promise<void> => {
 };
 
 const isAddressAllowed = async (req: Request, res: Response) => {
-    // TODO: Update config so node parses this env variable as a Boolean
-    if (CONFIG.API.enforceWhitelist === "TRUE") {
-        if (req.query.address == null || req.query.address.length === 0) {
-            res.send({
-                error: "Address not found. Please make sure that an address (string) is part of the request.",
-            });
-            return;
-        }
-        try {
-            const validAddresses = (await cacheManager.get(CacheKeys.FULL_ALLOWED_LIST)) as Set<string>;
-            const address: string = req.query.address as string;
-            const isAllowed = validAddresses.has(address);
-            res.send({
-                isAllowed,
-            });
-            return;
-        } catch (e) {
-            const err = e as Error;
-            console.log(`${err.name}, ${err.message}, ${err.stack}`);
-            res.status(400).send({ error: `Couldn't check validity of the address. ${err.message}` });
-        }
-    } else {
-        res.send({ isAllowed: true });
-    }
+    // TODO: remove the whole endpoint once frontend apps are adjusted.
+    // for now leaving the basic return just to make apps compatible, but open the gates for everyone
+    res.send({ isAllowed: true });
 };
 
 const stargate = async (req: Request, res: Response) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,6 @@ const server = http.createServer(router);
 const port: number | string = process.env.PORT || CONFIG.API.port;
 
 console.log("mainnet: ", CONFIG.API.mainnet);
-console.log("isAllowedList enforced: ", CONFIG.API.enforceWhitelist);
 
 contract
     .initializeContract()

--- a/types/globals/index.d.ts
+++ b/types/globals/index.d.ts
@@ -7,7 +7,6 @@ interface ConfigType {
     };
     API: {
         port: number;
-        enforceWhitelist: string;
         mainnet: string;
         cacheIntervalMs: number;
         allowedAddressesCSV: string;


### PR DESCRIPTION
This PR opens gates for everyone.

Additional info:
Since frontend apps are using the `/isAddressAllowed` endpoint, we cannot remove fully at the moment. However, we can always return `isAllowed: true`, no matter what argument is passed in the endpoint. 